### PR TITLE
fix: Resolve lifetime issue with parameter type J in iter_errors function

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -31,7 +31,7 @@ pub async fn try_validate<J: Json>(
     Ok(validator_for(schema).await?.validate(instance))
 }
 
-pub async fn iter_errors<'s, 'i, J: Json>(
+pub async fn iter_errors<'s, 'i, J: Json + 'static>(
     schema: &'s J,
     instance: &'i J,
 ) -> ValidationErrorIter<'static, 'i, J> {
@@ -40,7 +40,7 @@ pub async fn iter_errors<'s, 'i, J: Json>(
         .expect("Invalid schema")
 }
 
-pub async fn try_iter_errors<'s, 'i, J: Json>(
+pub async fn try_iter_errors<'s, 'i, J: Json + 'static>(
     schema: &'s J,
     instance: &'i J,
 ) -> BuildResult<ValidationErrorIter<'static, 'i, J>> {
@@ -48,13 +48,16 @@ pub async fn try_iter_errors<'s, 'i, J: Json>(
     Ok(validator.iter_errors_once(instance))
 }
 
-pub async fn evaluate<'i, J: Json>(instance: &'i J, schema: &J) -> Output<'static, 'i, J> {
+pub async fn evaluate<'i, J: Json + 'static>(
+    instance: &'i J,
+    schema: &J,
+) -> Output<'static, 'i, J> {
     try_evaluate(instance, schema)
         .await
         .expect("Invalid schema")
 }
 
-pub async fn try_evaluate<'i, J: Json>(
+pub async fn try_evaluate<'i, J: Json + 'static>(
     instance: &'i J,
     schema: &J,
 ) -> BuildResult<Output<'static, 'i, J>> {


### PR DESCRIPTION
Description:
When compiling the code, the compiler reports that the parameter type J may not have a long enough lifetime and needs to satisfy the 'static lifetime. This is because the function iter_errors returns a ValidationErrorIter containing a 'static lifetime, while the parameters schema and instance are of type &'s J and &'i J respectively, and their lifetimes 's and 'i may not be long enough to cover the 'static lifetime requirement.

Solution:
To resolve this issue, we can add an explicit lifetime bound to the generic type J, ensuring it has a 'static lifetime. We can modify the function signature as follows:

```rust
pub async fn iter_errors<'s, 'i, J: Json + 'static>(
    schema: &'s J,
    instance: &'i J,
) -> ValidationErrorIter<'static, 'i, J> {
    try_iter_errors(schema, instance)
        .await
        .expect("Invalid schema")
}
```